### PR TITLE
Build package from the main branch.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,5 @@
 name: build
+# Template taken from: https://github.com/moveit/moveit2_packages/blob/main/.github/workflows/build.yaml
 
 on:
   workflow_dispatch:
@@ -11,17 +12,17 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        ros_distro: [humble]
+        ros_distro: [humble, rolling]
     name: build_${{ matrix.ros_distro }}
     runs-on: ubuntu-22.04
     env:
-      repos_branch: 'main'
+      branch: ${{ github.ref_name }}
     steps:
       - uses: jspricke/ros-deb-builder-action@main
         with:
           DEB_DISTRO: jammy
           ROS_DISTRO: ${{ matrix.ros_distro }}
-          REPOS_FILE: https://raw.githubusercontent.com/Mailamaca/maila_packages/main/sources.repos
-          ROSDEP_SOURCE: "yaml https://raw.githubusercontent.com/Mailamaca/maila_packages/main/maila-rosdep.yaml"
+          REPOS_FILE: https://raw.githubusercontent.com/Mailamaca/maila_packages/${{ env.branch }}/sources.repos
+          ROSDEP_SOURCE: "yaml https://raw.githubusercontent.com/Mailamaca/maila_packages/${{ env.branch }}/maila-rosdep.yaml"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SQUASH_HISTORY: true

--- a/sources.repos
+++ b/sources.repos
@@ -1,13 +1,14 @@
 repositories:
-  stage:
-    type: git
-    url: https://github.com/Mailamaca/stage.git
-    version: test
-  stage_ros2:
-    type: git
-    url: https://github.com/Mailamaca/stage_ros2.git
-    version: test
   maila_2D_sim:
     type: git
     url: https://github.com/Mailamaca/maila_2D_sim.git
     version: main
+  stage:
+    type: git
+    url: https://github.com/Mailamaca/stage.git
+    version: main
+  stage_ros2:
+    type: git
+    url: https://github.com/Mailamaca/stage_ros2.git
+    version: main
+


### PR DESCRIPTION
After the PR with the fixes on the stage packages are merged (https://github.com/Mailamaca/stage/pull/2 and https://github.com/Mailamaca/stage_ros2/pull/2) our "buildfarm" should  build the packages directly from the main branch.

To see that this is working you can run the build pipeline on the https://github.com/Mailamaca/maila_packages/tree/test branch.